### PR TITLE
Downgrade pip to 18.x version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ help:
 docker/build:
 	docker-compose build
 
+.PHONY: docker/rebuild
+docker/rebuild:
+	docker-compose build --no-cache
+
 .PHONY: docker/up
 docker/up:
 	docker-compose up --build -d

--- a/docker/galaxy-api/Dockerfile
+++ b/docker/galaxy-api/Dockerfile
@@ -19,7 +19,10 @@ COPY galaxy-api/Pipfile \
 
 RUN python3.6 -m venv "${GALAXY_VENV}" \
     && source "${GALAXY_VENV}/bin/activate" \
-    && pip --no-cache-dir install -U pip wheel pipenv \
+    && pip --no-cache-dir install -U \
+        'pip<19.0' \
+        wheel \
+        pipenv \
     && cd /tmp/galaxy-api \
     && PIPENV_VERBOSITY=-1 pipenv install --ignore-pipfile
 

--- a/docker/pulp/Dockerfile
+++ b/docker/pulp/Dockerfile
@@ -19,7 +19,9 @@ COPY docker/pulp/requirements.txt /tmp/pulp/
 
 RUN python3.6 -m venv "${PULP_VENV}" \
     && source "${PULP_VENV}/bin/activate" \
-    && pip --no-cache-dir install -U pip wheel \
+    && pip --no-cache-dir install -U \
+        'pip<19.0' \
+        wheel \
     && cd /tmp/pulp \
     && pip install -r requirements.txt
 


### PR DESCRIPTION
Pip 19.x in order to support PEP517 creates `pip-wheel-metadata`
directory which may cause issues when using multiple editable
installs concurrently.