### PR TITLE
Add ansible to pulp docker image

### DIFF
--- a/docker/pulp/Dockerfile
+++ b/docker/pulp/Dockerfile
@@ -24,7 +24,7 @@ RUN python3.6 -m venv "${PULP_VENV}" \
         'pip<19.0' \
         wheel \
     && cd /tmp/pulp \
-    && pip install -r requirements.txt
+    && pip install --default-timeout 100 -r requirements.txt
 
 ENV PATH="/venv/bin:$PATH"
 

--- a/docker/pulp/requirements.txt
+++ b/docker/pulp/requirements.txt
@@ -1,3 +1,4 @@
+ansible==2.9.0b1
 psycopg2-binary
 mazer
 packaging


### PR DESCRIPTION
`pulp-ansible` installs a pypi version of the `galaxy-importer`. For the pulp worker container, this PR replaces `galaxy-importer` with a wheel built from source.

Update 2019-09-12: Not sure we want to replace pypi galaxy-importer with source here, so just leaving part to add ansible 2.9 into the docker image
