### PR TITLE
Add ansible.cfg that uses temp dir outside user home

### DIFF
--- a/docker/pulp/Dockerfile
+++ b/docker/pulp/Dockerfile
@@ -26,6 +26,8 @@ RUN python3.6 -m venv "${PULP_VENV}" \
     && cd /tmp/pulp \
     && pip install --default-timeout 100 -r requirements.txt
 
+COPY docker/pulp/ansible.cfg /etc/ansible/ansible.cfg
+
 ENV PATH="/venv/bin:$PATH"
 
 COPY docker/pulp/entrypoint.sh /entrypoint

--- a/docker/pulp/ansible.cfg
+++ b/docker/pulp/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+remote_tmp     = /tmp/ansible
+local_tmp      = /tmp/ansible


### PR DESCRIPTION
The default ansible temp dir `~/.ansible/tmp` is accessed by `ansible-doc` via the `galaxy-importer`. This works ok in the `galaxy-dev` local env, but on the CI environment it attempts to create dir `/.ansible/tmp` and fails.

This PR changes the default ansible temp dir to `/tmp/ansible` which is outside the user home (and in the local env, `/tmp` has greater permissions)