### PR TITLE
Copy pulp settings to docker image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
     ports:
       - '5002:8000'
     volumes:
-      - ./docker/pulp/settings.py:/etc/pulp/settings.py:ro
       - ./pulp-ansible:/code/pulp-ansible
       - pulp_data:/data
     depends_on:
@@ -46,7 +45,6 @@ services:
       - ./docker/pulp/env
     command: ['run', 'resource-manager']
     volumes:
-      - ./docker/pulp/settings.py:/etc/pulp/settings.py:ro
       - ./pulp-ansible:/code/pulp-ansible
       - pulp_data:/data
     depends_on:
@@ -59,7 +57,6 @@ services:
       - ./docker/pulp/env
     command: ['run', 'worker']
     volumes:
-      - ./docker/pulp/settings.py:/etc/pulp/settings.py:ro
       - ./pulp-ansible:/code/pulp-ansible
       - pulp_data:/data
     depends_on:
@@ -72,7 +69,6 @@ services:
       - ./docker/pulp/env
     command: ['run', 'content-app']
     volumes:
-      - ./docker/pulp/settings.py:/etc/pulp/settings.py:ro
       - ./pulp-ansible:/code/pulp-ansible
       - pulp_data:/data
     depends_on:

--- a/docker/pulp/Dockerfile
+++ b/docker/pulp/Dockerfile
@@ -27,6 +27,7 @@ RUN python3.6 -m venv "${PULP_VENV}" \
     && cd /tmp/pulp \
     && pip install --default-timeout 100 -r requirements.txt
 
+COPY docker/pulp/settings.py /etc/pulp/settings.py
 COPY docker/pulp/ansible.cfg /etc/ansible/ansible.cfg
 
 ENV PATH="/venv/bin:$PATH"


### PR DESCRIPTION
Copy pulp settings file to docker instead of mounting it from
local filesystem.