### PR TITLE
Update docker image ansible version

### DIFF
--- a/docker/pulp/requirements.txt
+++ b/docker/pulp/requirements.txt
@@ -1,4 +1,4 @@
-ansible==2.9.0b1
+ansible==2.9.0rc5
 psycopg2-binary
 
 git+https://github.com/pulp/pulpcore.git#egg=pulpcore


### PR DESCRIPTION
This change is necessary to use the latest `pulp-ansible` without getting a version conflict within the containers. The latest `pulp-ansible` depends on `galaxy-importer` that uses `ansible==2.9.0rc5`.

After 2.9.0 is released and not exclusively available in pre-releases, we should be able to remove the single pinned version.