### PR TITLE
Pin pulpcore version to 742b40e5563c64

### DIFF
--- a/docker/pulp/requirements.txt
+++ b/docker/pulp/requirements.txt
@@ -1,5 +1,3 @@
 ansible
 psycopg2-binary
-
-git+https://github.com/pulp/pulpcore.git#egg=pulpcore
-git+https://github.com/pulp/pulpcore-plugin.git#egg=pulpcore_plugin
+git+https://github.com/pulp/pulpcore.git@742b40e5563c6401f2d10e3d605cc2c502fd1a3e#egg=pulpcore


### PR DESCRIPTION
This is the pulpcore version bmbouter suggested
when pinned to. This includes the change
from CONTENT_HOST to CONTENT_PORT

Also removing the requirement on pulpcore-plugin
based on:

https://github.com/pulp/pulp_ansible/commit/68cdd13edc8543b2d160ce1418a3f8e5308e3874#diff-2eeaed663bd0d25b7e608891384b7298

(pulpcore-plugin is pulled in or incorporated by pulpcore now)