### PR TITLE
Update pulp_ansible submodule to not follow master branch and pin to commit e8a9176cef731

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,3 @@
 [submodule "pulp-ansible"]
 	path = pulp-ansible
 	url = git@github.com:pulp/pulp_ansible.git
-	branch = master


### PR DESCRIPTION
Remove 'branch = master' for pulp_ansible
submodule config to pin it to commit
e8a9176cef731

Related: https://github.com/ansible/galaxy-dev/pull/169
Related: https://github.com/ansible/galaxy-api/pull/127
Related: https://github.com/pulp/pulp_ansible/pull/249
Related: https://github.com/pulp/pulpcore/pull/370

This is based on:
pulp/pulp_ansible@e8a9176

which is based on pulpcore change:
pulp/pulpcore#370

which implements:
https://pulp.plan.io/issues/5629