### PR TITLE
Remove submodule galaxy-importer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,10 +2,6 @@
 	path = galaxy-api
 	url = git@github.com:ansible/galaxy-api.git
 	branch = master
-[submodule "galaxy-importer"]
-	path = galaxy-importer
-	url = git@github.com:ansible/galaxy-importer.git
-	branch = master
 [submodule "pulp-ansible"]
 	path = pulp-ansible
 	url = git@github.com:pulp/pulp_ansible.git


### PR DESCRIPTION
galaxy-importer is installed from PyPI and local submodule
is not used.